### PR TITLE
avoid error storms with disconnected controllers

### DIFF
--- a/phytronApp/src/phytronAxisMotor.cpp
+++ b/phytronApp/src/phytronAxisMotor.cpp
@@ -146,8 +146,7 @@ phytronController::phytronController(const char *phytronPortName, const char *as
 extern "C" int phytronCreateController(const char *phytronPortName, const char *asynPortName,
                                    int movingPollPeriod, int idlePollPeriod, double timeout)
 {
-  phytronController *pphytronController = new phytronController(phytronPortName, asynPortName, movingPollPeriod/1000., idlePollPeriod/1000., timeout);
-  pphytronController = NULL;
+  new phytronController(phytronPortName, asynPortName, movingPollPeriod/1000., idlePollPeriod/1000., timeout);
   return asynSuccess;
 }
 

--- a/phytronApp/src/phytronAxisMotor.cpp
+++ b/phytronApp/src/phytronAxisMotor.cpp
@@ -441,7 +441,7 @@ void phytronController::report(FILE *fp, int level)
   */
 phytronAxis* phytronController::getAxis(asynUser *pasynUser)
 {
-  return static_cast<phytronAxis*>(asynMotorController::getAxis(pasynUser));
+  return dynamic_cast<phytronAxis*>(asynMotorController::getAxis(pasynUser));
 }
 
 /** Returns a pointer to an phytronAxis object.
@@ -450,7 +450,7 @@ phytronAxis* phytronController::getAxis(asynUser *pasynUser)
   */
 phytronAxis* phytronController::getAxis(int axisNo)
 {
-  return static_cast<phytronAxis*>(asynMotorController::getAxis(axisNo));
+  return dynamic_cast<phytronAxis*>(asynMotorController::getAxis(axisNo));
 }
 
 /**

--- a/phytronApp/src/phytronAxisMotor.h
+++ b/phytronApp/src/phytronAxisMotor.h
@@ -106,6 +106,7 @@ private:
   phytronStatus setVelocity(double minVelocity, double maxVelocity, int moveType);
   phytronStatus setAcceleration(double acceleration, int movementType);
 
+  phytronStatus lastStatus;
   size_t response_len;
 
 friend class phytronController;
@@ -166,7 +167,7 @@ protected:
 
 private:
   double timeout_;
-
+  phytronStatus lastStatus;
 
 friend class phytronAxis;
 };


### PR DESCRIPTION
We recently had an issue with multi-gigabyte soft IOC log files where we actually ran out of disk space. The phytronMotor module was identified as one of the chief culprits, so I wanted to see if this could be fixed. The patch is quite repetitive; it makes the same change for most uses of asynPrint in the code. This is ugly and normally the first thing I would do is to extract this functionality into a separate procedure or method. But asynPrint uses varargs and is defined in asyn as a macro with complicated #ifdefs depending on OS and compiler. This made me think it may not be easily possible to factor this out in a portable manner.

The other two patches are simple and obvious cleanups.