### PR TITLE
Fix reference on limit switch.

### DIFF
--- a/phytronApp/src/phytronAxisMotor.h
+++ b/phytronApp/src/phytronAxisMotor.h
@@ -109,6 +109,10 @@ private:
   phytronStatus lastStatus;
   size_t response_len;
 
+  // Workaround for homing type limit
+  int homeForward;
+  int homeState;
+
 friend class phytronController;
 };
 


### PR DESCRIPTION
Hello Kevin,
if you remember, I asked for help on a failing reference on limit switches at techtalk (28.3.) I fixed this and it worked fine since that. 
Another point is, I developed a support for phyMotion IO cards and would like to share this. This support is independant from the motor support. Are you the right one to be called for that?

Best regards

Bernhard