### PR TITLE
Fix limit refaccelleration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ auto_settings.sav*
 auto_positions.sav*
 .ccfxprepdir/
 *.local
+phytronMotors.*

--- a/phytronApp/src/phytronAxisMotor.cpp
+++ b/phytronApp/src/phytronAxisMotor.cpp
@@ -714,7 +714,7 @@ phytronStatus phytronAxis::setAcceleration(double acceleration, int moveType)
   } else if(moveType == homeMove){
     sprintf(pC_->outString_, "M%.1fP09=%f", axisModuleNo_, acceleration);
   } else if (moveType == stopMove){
-    sprintf(pC_->outString_, "M%.1fP07=%f", axisModuleNo_, acceleration);
+    sprintf(pC_->outString_, "M%.1fP15=%f", axisModuleNo_, acceleration);
   }
 
   return pC_->sendPhytronCommand(pC_->outString_, pC_->inString_, MAX_CONTROLLER_STRING_SIZE, &this->response_len);


### PR DESCRIPTION
For the stopMove command  there is the record.ACCL acceleration parameter used as ramp parameter and set to P07 of the phyMotion axis. This s not correct. P07 is used for emergency Stop and if limit switches are hit. So it has to be set to the fastest slow down possible. The phytronAxisMotor doesn't use the emergency stop command m.n.SN but the normal axis stop  command m.nS. Here the drive ramp P15, not P07 is used to decelerate (see page 60 of the pyLogic documentation).
Setting P07 to a slow deceleration without loosing steps causes the motor to run deep into the limit switches and we made it to run beyond it. 