### PR TITLE
Update Phytron_I1AM01.db for BiSS interface

### DIFF
--- a/phytronApp/Db/Phytron_I1AM01.db
+++ b/phytronApp/Db/Phytron_I1AM01.db
@@ -696,6 +696,12 @@ record(bi, "$(P)$(M)-PWR-STAGE-MODE_GET")
 # 6: SSI Gray code 5.5V
 # 7: EnDat 5.0V
 # 8: EnDat 5.5V
+# 9: resolver
+# 10: LVDT 4-wire
+# 11: LVDT 5/6-wire
+# 12: BiSS 5.0 V
+# 13: BiSS 24.0 V
+
 ################################################################################
 record(mbbo, "$(P)$(M)-ENC-TYP_SET")
 {
@@ -720,6 +726,16 @@ record(mbbo, "$(P)$(M)-ENC-TYP_SET")
     field(SVVL, "7")
     field(EIST, "EnDat 5.5V")
     field(EIVL, "8")
+    field(NIST, "resolver")
+    field(NIVL, "9")
+    field(TEST, "LVDT 4-wire")
+    field(TEVL, "10")
+    field(ELST, "LVDT 5/6-wire")
+    field(ELVL, "11")
+    field(TVST, "BiSS 5.0 V")
+    field(TVVL, "12")
+    field(TTST, "BiSS 24.0 V")
+    field(TTVL, "13")
     field(FLNK, "$(P)$(M)-ENC-TYP_GET")
 }
 
@@ -746,6 +762,16 @@ record(mbbi, "$(P)$(M)-ENC-TYP_GET")
     field(SVVL, "7")
     field(EIST, "EnDat 5.5V")
     field(EIVL, "8")
+    field(NIST, "resolver")
+    field(NIVL, "9")
+    field(TEST, "LVDT 4-wire")
+    field(TEVL, "10")
+    field(ELST, "LVDT 5/6-wire")
+    field(ELVL, "11")
+    field(TVST, "BiSS 5.0 V")
+    field(TVVL, "12")
+    field(TTST, "BiSS 24.0 V")
+    field(TTVL, "13")
     field(PINI, "YES")
 }
 


### PR DESCRIPTION
The "phyLOGIC Command Reference for the phyMOTION Controller" document had been updated for BiSS interface for encoders.
I have committed for encoder type PVs and, I think there is no extra necessary code improvements for BiSS interface. But I'm wondering that if there should be necessary code improvements on phytronAxisMotor.cpp.

phyLOGIC document: [ma-phylogic-en.pdf](https://github.com/epics-motor/motorPhytron/files/10243719/ma-phylogic-en.pdf)